### PR TITLE
STO-908 - Attempting to bump ansible to 2.9.13

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     install_requires = [
         "boto3",
         "botocore",
-        "ansible==2.8.15"
+        "ansible==2.9.13"
     ],
     packages = find_packages(),
     description = "Helpers for developing ansible plugins/modules/etc",


### PR DESCRIPTION
Trying to bump the ansible version for ansible_helpers to align with the ansible upgrade internally.